### PR TITLE
Fix tokenizer BOS token id

### DIFF
--- a/model/tokenizer.py
+++ b/model/tokenizer.py
@@ -33,7 +33,7 @@ class Tokenizer(TextEncoder):
 
         self.pad_index = self.tokenizer.pad_token_id
         self.eos_index = self.tokenizer.eos_token_id
-        self.bos_index = self.tokenizer.eos_token_id
+        self.bos_index = self.tokenizer.bos_token_id
         self.vocab = self.tokenizer.get_vocab()
         self.speaker1_index = self.vocab["<speaker1>"]
         self.speaker2_index = self.vocab["<speaker2>"]


### PR DESCRIPTION
In the _Tokenizer's_ constructor you have:

`self.bos_index = self.tokenizer.eos_token_id`

And it should be:

`self.bos_index = self.tokenizer.bos_token_id`